### PR TITLE
Fix punching bag script and knockback direction

### DIFF
--- a/game_jam_game/scenes/punching_bag.tscn
+++ b/game_jam_game/scenes/punching_bag.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=11 format=3 uid="uid://bqebe3jk28qtu"]
 
-[ext_resource type="Script" uid="uid://phvcwnbty7hf" path="res://scenes/punching_bag.gd" id="1_drm4u"]
+[ext_resource type="Script" uid="uid://cktagk2sar8ok" path="res://scripts/punching_bag.gd" id="1_drm4u"]
 [ext_resource type="Script" uid="uid://d341eysla0hdt" path="res://scripts/hit_hurt_boxes/hurtbox.gd" id="3_8cb5e"]
 [ext_resource type="Texture2D" uid="uid://438fynowu56s" path="res://assets/sprites/mario.png" id="3_m4gd1"]
 

--- a/game_jam_game/scripts/air_attack.gd
+++ b/game_jam_game/scripts/air_attack.gd
@@ -10,15 +10,18 @@ extends State
 
 var sword_anim: AnimationPlayer
 var initial_horizontal_velocity: float
+var hitbox: HitBox
 
 func enter() -> void:
-	super()
+        super()
 	
 	
 	
-	# Store initial horizontal velocity and apply damping
-	initial_horizontal_velocity = parent.velocity.x
-	parent.velocity.x *= air_attack_horizontal_damping
+        hitbox = parent.get_node("AnimatedSprite2D/Sword/Sprite2D/HitBox") as HitBox
+
+        # Store initial horizontal velocity and apply damping
+        initial_horizontal_velocity = parent.velocity.x
+        parent.velocity.x *= air_attack_horizontal_damping
 	
 
 	
@@ -27,14 +30,17 @@ func process_input(_event: InputEvent):
 	sword_anim = parent.get_node("AnimatedSprite2D/Sword/AnimationPlayer") as AnimationPlayer
 	if Input.is_action_pressed("up"):
 		sword_anim.play("up_ward_swing")
+                hitbox.attack_dir = "up"
 		print("Playing Upward Air Attack Animation")
 		return idle_state
 	elif Input.is_action_pressed("crouch"):	# or "down"
 		sword_anim.play("down_ward_swing")
+                hitbox.attack_dir = "down"
 		print("Playing Downward Air Attak Animation")
 		return idle_state
 	else:
 		sword_anim.play("swing")
+                hitbox.attack_dir = "side"
 		print("Playing Attack Animation")
 		return idle_state
 

--- a/game_jam_game/scripts/ground_attack.gd
+++ b/game_jam_game/scripts/ground_attack.gd
@@ -10,15 +10,13 @@ extends State
 @export var deceleration: float
 
 var sword_anim: AnimationPlayer
+var hitbox: HitBox
 
 
 
 func enter() -> void:
-	super()
-	
-	
-	
-	#var sword_hitbox = parent.get_node("Sword/Sprite/Hitbox")  as Area2D
+        super()
+        hitbox = parent.get_node("AnimatedSprite2D/Sword/Sprite2D/HitBox") as HitBox
 
 func process_input(_event: InputEvent) -> State:
 	sword_anim = parent.get_node("AnimatedSprite2D/Sword/AnimationPlayer") as AnimationPlayer
@@ -26,14 +24,17 @@ func process_input(_event: InputEvent) -> State:
 		# … then look at what the player is holding **right now**.
 	if Input.is_action_pressed("up"):
 		sword_anim.play("up_ward_swing")
+                hitbox.attack_dir = "up"
 		print("Playing Upward Swing Animation")
 		return idle_state
 	elif Input.is_action_pressed("crouch"):	# or "down"
 		sword_anim.play("down_ward_swing")
+                hitbox.attack_dir = "down"
 		print("Playing Downward Swing Animation")
 		return crouch_state
 	else:
 		sword_anim.play("swing")
+                hitbox.attack_dir = "side"
 		print("Playing Swing Animation")
 		return idle_state
 

--- a/game_jam_game/scripts/hit_hurt_boxes/hitbox.gd
+++ b/game_jam_game/scripts/hit_hurt_boxes/hitbox.gd
@@ -4,8 +4,10 @@ extends Area2D
 
 @export
 var damage := 10
-@export 
+@export
 var knockback_multiplier: float = 200.0
+@export
+var attack_dir: String = "side"  # "up", "down", or "side"
 
 func _init() -> void:
 	collision_layer = 4

--- a/game_jam_game/scripts/hit_hurt_boxes/hurtbox.gd
+++ b/game_jam_game/scripts/hit_hurt_boxes/hurtbox.gd
@@ -17,6 +17,21 @@ func _on_area_entered(hitbox: HitBox) -> void:
 	if owner.has_method("take_damage"):
 		owner.take_damage(hitbox.damage)
 		
-	if owner.has_method("apply_knockback"):
-		var dir: Vector2 = (owner.global_position - hitbox.global_position).normalized()
-		owner.apply_knockback(dir * hitbox.knockback_multiplier)
+       if owner.has_method("apply_knockback"):
+               var horiz_dir := sign(owner.global_position.x - hitbox.global_position.x)
+               if horiz_dir == 0:
+                       horiz_dir = 1 # default knock right if overlapping
+
+               var dir: Vector2
+               match hitbox.attack_dir:
+                       "up":
+                               dir = Vector2(horiz_dir * 0.2, -1)
+                       "down":
+                               dir = Vector2(horiz_dir * 0.2, 1)
+                       "side":
+                               dir = Vector2(horiz_dir, -0.2)
+                       _:
+                               dir = Vector2(horiz_dir, -0.5)
+
+               dir = dir.normalized()
+               owner.apply_knockback(dir * hitbox.knockback_multiplier)


### PR DESCRIPTION
## Summary
- make punching bag use the correct script
- knock opponents back horizontally based on where the hit came from
- set knockback vector depending on attack direction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d441e7460832aa2c2da26f9bbc3b3