### PR TITLE
Ensure player mirroring uses skeleton center

### DIFF
--- a/game_jam_game/scripts/player.gd
+++ b/game_jam_game/scripts/player.gd
@@ -11,6 +11,7 @@ signal loop_started
  
 @onready var animations: AnimationPlayer = $AnimationPlayer
 @onready var sprite: Node2D = $Polygons
+@onready var skeleton: Node2D = $Skeleton2D
 @onready var sword: Node2D = get_node_or_null("Sword")
 @onready var camera: Camera2D = $Camera2D
 
@@ -240,8 +241,13 @@ func update_sword_position() -> void:
 
 
 func set_facing_left(is_left: bool) -> void:
-		facing_left = is_left
-		scale.x = -1 if is_left else 1
+	if facing_left == is_left:
+		return
+	var center := skeleton.global_position
+	facing_left = is_left
+	scale.x = -1 if is_left else 1
+	var new_center := skeleton.global_position
+	global_position += center - new_center
 
 
 func is_facing_left() -> bool:


### PR DESCRIPTION
## Summary
- Keep player centered when flipping by using the skeleton's position
- Store Skeleton2D reference for mirroring calculations

## Testing
- `godot3 --headless --quit` *(fails: Can't open project at '.../project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine. Expected config version: 4.)*

------
https://chatgpt.com/codex/tasks/task_e_688f070ce58c832a8502a29dd7174242