### PR TITLE
Fix mis-indentation in player script

### DIFF
--- a/game_jam_game/scripts/player.gd
+++ b/game_jam_game/scripts/player.gd
@@ -131,10 +131,10 @@ func _unhandled_input(event: InputEvent) -> void:
 		if is_ghost_mode:
 			set_ghost_mode(false)
 			print("Debug: Manually exited ghost mode")
-		else:
-			print("Debug: Simulating player death for testing...")
-						set_health(0)
-						die()
+                else:
+                        print("Debug: Simulating player death for testing...")
+                        set_health(0)
+                        die()
 		
 	# Track when input buttons are first pressed for hold time calculation
 	for action in input_actions:


### PR DESCRIPTION
## Summary
- fix indentation in Player script ghost-mode debug block

## Testing
- `godot3 --headless --check game_jam_game/project.godot` *(fails: Can't open project ... config_version (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_688f2b01fc40832ab0ff68a29819a395