### PR TITLE
Start timer for initial track in CassetteButtonlessUI

### DIFF
--- a/game_jam_game/scripts/cassette_buttonless_ui.gd
+++ b/game_jam_game/scripts/cassette_buttonless_ui.gd
@@ -714,6 +714,10 @@ func switch_to_track(track_number: int):
 				return
 
 		if current_track == track_number:
+				_update_timer_display()
+				_update_progress_bar()
+				if not is_timer_running and timer_per_track[current_track] > 0:
+					start_timer()
 				return
 
 		var old_track = current_track


### PR DESCRIPTION
## Summary
- start timer even when switching to current track in CassetteButtonlessUI

## Testing
- `godot3 --headless --version`


------
https://chatgpt.com/codex/tasks/task_e_688f2fab7dc0832a96aad1ddf7f0b965