### PR TITLE
Start track one timer immediately

### DIFF
--- a/game_jam_game/scripts/cassette_buttonless_ui.gd
+++ b/game_jam_game/scripts/cassette_buttonless_ui.gd
@@ -178,11 +178,13 @@ func _ready():
 		timer_progress_bar.value = 0.0  # Start at 0 (no progress yet)
 		print("Progress bar initialized: max=", timer_progress_bar.max_value, ", min=", timer_progress_bar.min_value)
 	
-		# Initialize track timers
-		_initialize_timer_per_track()
+                # Initialize track timers
+                _initialize_timer_per_track()
+                # Start the timer immediately so track 1 begins counting down
+                start_timer()
 
-		# Initialize health dictionaries
-		_initialize_health_per_track()
+                # Initialize health dictionaries
+                _initialize_health_per_track()
 
 		# Initialize hearts system
 		_initialize_hearts()


### PR DESCRIPTION
## Summary
- Start timer immediately after initializing track timers in CassetteButtonlessUI to ensure track 1 countdown begins at launch.

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_688f32b44910832a92b0879725534dfb