### PR TITLE
Ensure cassette UI subscribes to active player on startup

### DIFF
--- a/game_jam_game/scripts/cassette_buttonless_ui.gd
+++ b/game_jam_game/scripts/cassette_buttonless_ui.gd
@@ -190,6 +190,7 @@ func _ready():
 		_initialize_hearts()
 	
 	# Start the countdown timer for track 1
+	current_track = 0
 	switch_to_track(1)
 	
 	# Drop red button by default when game starts
@@ -716,11 +717,13 @@ func switch_to_track(track_number: int):
 				return
 
 		if current_track == track_number:
-				_update_timer_display()
-				_update_progress_bar()
-				if not is_timer_running and timer_per_track[current_track] > 0:
-					start_timer()
-				return
+			_connect_to_active_player()
+			_update_hearts_display()
+			_update_timer_display()
+			_update_progress_bar()
+			if not is_timer_running and timer_per_track[current_track] > 0:
+				start_timer()
+			return
 
 		var old_track = current_track
 


### PR DESCRIPTION
## Summary
- Subscribe the UI to the active player's health when switching to a track that's already active
- Reset `current_track` before the initial `switch_to_track(1)` to force full initialization

## Testing
- `gdformat --check game_jam_game/scripts/cassette_buttonless_ui.gd`
- `gdlint game_jam_game/scripts/cassette_buttonless_ui.gd`

------
https://chatgpt.com/codex/tasks/task_e_688f35dfca80832a936f790a65a94f58