### PR TITLE
Instantiate Player in track and forward controls

### DIFF
--- a/game_jam_game/scripts/level_architecture/track.gd
+++ b/game_jam_game/scripts/level_architecture/track.gd
@@ -1,3 +1,22 @@
 class_name Track
 
 extends Node
+
+const PLAYER_SCENE := preload("res://scenes/player.tscn")
+
+var _player: Player
+
+func _ready() -> void:
+	_player = PLAYER_SCENE.instantiate()
+	add_child(_player)
+
+func get_player() -> Player:
+	return _player
+
+func receive_input(event: InputEvent) -> void:
+	if _player:
+		_player._unhandled_input(event)
+
+func set_ghost_mode(enabled: bool) -> void:
+	if _player:
+		_player.set_ghost_mode(enabled)


### PR DESCRIPTION
## Summary
- Spawn a Player scene when a Track node is ready and expose the player via `get_player`
- Forward input events and ghost mode toggles from Track to the embedded Player

## Testing
- `godot3 --headless --quit` *(fails: Can't open project... expected config version 4)*

------
https://chatgpt.com/codex/tasks/task_e_688f39a7a6c0832a9dcd8d579f7eadab