### PR TITLE
Stop replaying players from reacting to live input

### DIFF
--- a/game_jam_game/scripts/player.gd
+++ b/game_jam_game/scripts/player.gd
@@ -149,27 +149,28 @@ func _unhandled_input(event: InputEvent) -> void:
 	state_machine.process_input(event)
 
 func _physics_process(delta: float) -> void:
-	
-	if is_replaying:
-		if track1.length == 0:
-			return
-		var tick = track1.get_at(track_replay_index)
-		self.position = tick.position
-		self.velocity = tick.velocity
-		self.input_just_pressed = tick.input
-		track_replay_index = (track_replay_index+ 1) % track1.length
-	else:
-		track1.push({
-		"input" : input_just_pressed,
-		"seconds" : total_time,
-		"health" : current_health,  # Use actual current health
-		"position": self.position,
-		"velocity": self.velocity
-	})
-		if track1.is_full():
-			track_replay_index = 0
-			is_replaying = true
-			emit_signal("loop_started")
+
+        if is_replaying:
+                if track1.length == 0:
+                        return
+                var tick = track1.get_at(track_replay_index)
+                self.position = tick.position
+                self.velocity = tick.velocity
+                self.input_just_pressed = tick.input
+                track_replay_index = (track_replay_index + 1) % track1.length
+                return
+        else:
+                track1.push({
+                "input" : input_just_pressed,
+                "seconds" : total_time,
+                "health" : current_health,  # Use actual current health
+                "position": self.position,
+                "velocity": self.velocity
+        })
+                if track1.is_full():
+                        track_replay_index = 0
+                        is_replaying = true
+                        emit_signal("loop_started")
 
 	
 	# Update invincibility timer and flashing effect
@@ -204,10 +205,12 @@ func _physics_process(delta: float) -> void:
 func buffer_jump():
 	buffer_input("jump")
 func _process(delta: float) -> void:
-	# Poll inputs first to ensure they're captured for this frame
-	poll_inputs()
-	
-	state_machine.process_frame(delta)
+        # Poll inputs first to ensure they're captured for this frame
+        poll_inputs()
+        if is_replaying:
+                return
+
+        state_machine.process_frame(delta)
 	
 
 	if animations.flip_h != last_flip_h:


### PR DESCRIPTION
## Summary
- stop physics update for replaying players before the state machine can read live input
- skip per-frame state machine updates while a player is replaying a recorded track

## Testing
- `godot3 --headless --path game_jam_game --quit` *(fails: Can't open project at '/workspace/game_jam/game_jam_game/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine. Expected config version: 4.)*

------
https://chatgpt.com/codex/tasks/task_e_688f4adb69e4832a9717469e4107ee14