### PR TITLE
Consume input events after active track processing

### DIFF
--- a/game_jam_game/scripts/level_architecture/player_manager.gd
+++ b/game_jam_game/scripts/level_architecture/player_manager.gd
@@ -48,6 +48,7 @@ func _input(event: InputEvent) -> void:
 	# ---- Any other input goes to the active track ----------------
 	if tracks.size() > 0:
 		tracks[active_index].receive_input(event)
+		event.consume()
 
 ### ----------------------------------------------------------------
 func _switch_to(new_idx: int) -> void:


### PR DESCRIPTION
## Summary
- Prevent input events from propagating to inactive tracks by consuming them after the active track handles them

## Testing
- `godot4 --headless --path game_jam_game -s res://test_dummy.gd` *(command not found)*
- `apt-get install -y godot4` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f585d2b80832aa2aff700cabf9608