### PR TITLE
Decouple active track from ring buffer playback

### DIFF
--- a/game_jam_game/scripts/player.gd
+++ b/game_jam_game/scripts/player.gd
@@ -5,6 +5,7 @@ class_name Player
 @onready var track1: RingBuffer = RingBuffer.create_by_seconds(15, Engine.get_physics_ticks_per_second())
 var is_replaying: bool = false
 var track_replay_index: int = 0
+var loop_triggered: bool = false
 
 signal loop_started
 signal health_changed(new_health: int)
@@ -150,27 +151,26 @@ func _unhandled_input(event: InputEvent) -> void:
 
 func _physics_process(delta: float) -> void:
 
-	if is_replaying:
-		if track1.length == 0:
-			return
-		var tick = track1.get_at(track_replay_index)
-		self.position = tick.position
-		self.velocity = tick.velocity
-		self.input_just_pressed = tick.input
-		track_replay_index = (track_replay_index + 1) % track1.length
-		return
-	else:
-		track1.push({
-				"input" : input_just_pressed,
-				"seconds" : total_time,
-				"health" : current_health,  # Use actual current health
-				"position": self.position,
-				"velocity": self.velocity
-		})
-		if track1.is_full():
-			track_replay_index = 0
-			is_replaying = true
-			emit_signal("loop_started")
+        if is_replaying:
+                if track1.length == 0:
+                        return
+                var tick = track1.get_at(track_replay_index)
+                self.position = tick.position
+                self.velocity = tick.velocity
+                self.input_just_pressed = tick.input
+                track_replay_index = (track_replay_index + 1) % track1.length
+                return
+        else:
+                track1.push({
+                                "input" : input_just_pressed,
+                                "seconds" : total_time,
+                                "health" : current_health,  # Use actual current health
+                                "position": self.position,
+                                "velocity": self.velocity
+                })
+                if track1.is_full() and not loop_triggered:
+                        loop_triggered = true
+                        emit_signal("loop_started")
 
 	# Update invincibility timer and flashing effect
 	update_invincibility(delta)
@@ -716,8 +716,13 @@ func die() -> void:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 func set_ghost_mode(ghost: bool) -> void:
-	"""Set the player's ghost mode state"""
-	is_ghost_mode = ghost
+        """Set the player's ghost mode state"""
+        is_ghost_mode = ghost
+        is_replaying = ghost
+        if is_replaying:
+                track_replay_index = 0
+        else:
+                loop_triggered = false
 	
 	if is_ghost_mode:
 		print("Player entering ghost mode...")

--- a/game_jam_game/scripts/player_manager.gd
+++ b/game_jam_game/scripts/player_manager.gd
@@ -68,29 +68,21 @@ func _on_loop_started(looping_track_idx: int) -> void:
 # 
 # Enable input on the chosen track, disable on the others
 func activate_track(idx: int) -> void:
-	# Check if we're already on this track to prevent unnecessary work
-	if active_track_idx == idx:
-		return
-		
-	for i in range(tracks.size()):
-		var is_active := i == idx
-		tracks[i].set_process_input(is_active)
-		tracks[i].visible = i <= idx  # keep current and prior tracks visible
+        # Check if we're already on this track to prevent unnecessary work
+        if active_track_idx == idx:
+                return
 
-		#for i in range(tracks.size()):
-		#	var is_active = i == idx
-		#	tracks[i].set_process_input(is_active)
-		#	tracks[i].visible = i <= idx  # Keep completed tracks visible
-		
-		# Handle ghost mode transitions
-		if is_active and tracks[i].has_method("set_ghost_mode"):
-			# When activating a track, exit ghost mode if the player was a ghost
-			tracks[i].set_ghost_mode(false)
-				#if tracks[i].has_method("set_ghost_mode"):
-				#	tracks[i].set_ghost_mode(false)
-				#	print("[PlayerManager] Restored player from ghost mode on track %d" % i)
-	
-	active_track_idx = idx
+        for i in range(tracks.size()):
+                var is_active := i == idx
+                tracks[i].set_process_input(is_active)
+                tracks[i].visible = i <= idx  # keep current and prior tracks visible
+
+                # Handle ghost mode transitions
+                if tracks[i].has_method("set_ghost_mode"):
+                        tracks[i].set_ghost_mode(i < idx)
+
+        active_track_idx = idx
+
 	
 	# Move the main camera to follow the active player
 	if main_camera and idx < tracks.size():

--- a/game_jam_game/scripts/ring_buffer/ring_buffer.gd
+++ b/game_jam_game/scripts/ring_buffer/ring_buffer.gd
@@ -20,12 +20,12 @@ func _init(buffer_size:int) -> void:
 # -- Buffer Methods -- #
 
 func push(value:Variant) -> void:
-	if length == buffer_size:
-		return
-	buffer[head] = value
-	head = (head + 1) % buffer_size
-	if length < buffer_size:
-		length += 1
+        buffer[head] = value
+        head = (head + 1) % buffer_size
+        if length < buffer_size:
+                length += 1
+        else:
+                tail = (tail + 1) % buffer_size
 
 func clear() -> void:
 	head = 0


### PR DESCRIPTION
## Summary
- keep recording inputs in a true ring buffer and emit loop events without forcing replay
- toggle replay based on ghost mode so active tracks always obey real-time input
- switch non-active tracks to ghost mode via PlayerManager

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f6111c1c4832a9c63d0c6190b8bc6