### PR TITLE
Use per-track ghost flags for switching

### DIFF
--- a/game_jam_game/scripts/player.gd
+++ b/game_jam_game/scripts/player.gd
@@ -9,6 +9,7 @@ var loop_triggered: bool = false
 
 signal loop_started
 signal health_changed(new_health: int)
+signal died
  
 @onready var animations: AnimatedSprite2D = $AnimatedSprite2D
 @onready var sword: Node2D = $AnimatedSprite2D/Sword
@@ -701,6 +702,7 @@ func die() -> void:
 	
 	# Instead of restarting the game, enter ghost mode
 	set_ghost_mode(true)
+        emit_signal("died")
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # GHOST MODE SYSTEM

--- a/game_jam_game/scripts/player_manager.gd
+++ b/game_jam_game/scripts/player_manager.gd
@@ -18,6 +18,7 @@ var track_colors: Array[Color] = [
 
 # Holds the instantiated Player tracks
 var tracks: Array[Player] = []
+var ghost_flags: Array[bool] = []
 
 # Index of the currently active track
 var active_track_idx: int = -1
@@ -38,6 +39,10 @@ func _ready() -> void:
 		# Listen for when the player's ring buffer starts looping
 		player.connect("loop_started", Callable(self, "_on_loop_started").bind(i))
 		tracks.append(player)
+                ghost_flags.append(false)
+
+                if player.has_signal("died"):
+                        player.connect("died", Callable(self, "_on_player_died").bind(i))
 		# Disable input on all until we activate one
 		player.set_process_input(false)
 
@@ -77,18 +82,19 @@ func _on_loop_started(looping_track_idx: int) -> void:
 # 
 # Enable input on the chosen track, disable on the others
 func activate_track(idx: int) -> void:
-	# Check if we're already on this track to prevent unnecessary work
-	if active_track_idx == idx:
-		return
+        # Check if we're already on this track to prevent unnecessary work
+        if active_track_idx == idx:
+                return
 
-	for i in range(tracks.size()):
-		var is_active := i == idx
-		tracks[i].set_process_input(is_active)
-		tracks[i].visible = i <= idx  # keep current and prior tracks visible
+        for i in range(tracks.size()):
+                var is_active := i == idx
+                tracks[i].set_process_input(is_active)
+                tracks[i].visible = i <= idx  # keep current and prior tracks visible
 
-		# Handle ghost mode transitions
-		if tracks[i].has_method("set_ghost_mode"):
-			tracks[i].set_ghost_mode(i < idx)
+                # Handle ghost mode transitions
+                if tracks[i].has_method("set_ghost_mode"):
+                        var should_ghost = ghost_flags[i] and i != idx
+                        tracks[i].set_ghost_mode(should_ghost)
 
 	active_track_idx = idx
 
@@ -268,3 +274,8 @@ func trigger_cassette_event(event_type: String):
 		cassette_ui.trigger_cassette_action(event_type)
 	else:
 		print("[PlayerManager] Warning: No UI reference for event: ", event_type)
+
+func _on_player_died(idx: int) -> void:
+        if idx >= 0 and idx < ghost_flags.size():
+                ghost_flags[idx] = true
+


### PR DESCRIPTION
## Summary
- Track players' ghost state and activate ghost mode only for dead tracks
- Emit `died` signals from players and hook managers to mark ghost tracks
- Adjust track activation logic to respect per-track ghost flags

## Testing
- `godot3 --version`
- `godot3 -s test_dummy.gd` *(fails: Can't open project, config_version 5 is from a newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_688f6b6af840832ab3ead885b0d40ea2